### PR TITLE
Escape backslash in key name regex

### DIFF
--- a/JSON Key-Value.YAML-tmLanguage
+++ b/JSON Key-Value.YAML-tmLanguage
@@ -15,7 +15,7 @@ patterns:
   end: \*/
   name: comment.block.jsonkv
 - comment: Key names
-  match: '"(?i)([^\"]+)"\s*?:'
+  match: '"(?i)([^\\"]+)"\s*?:'
   captures:
     '1':
       name: keyword.other.name.jsonkv

--- a/JSON Key-Value.tmLanguage
+++ b/JSON Key-Value.tmLanguage
@@ -40,7 +40,7 @@
 			<key>comment</key>
 			<string>Key names</string>
 			<key>match</key>
-			<string>"(?i)([^\"]+)"\s*?:</string>
+			<string>"(?i)([^\\"]+)"\s*?:</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
The current definition sees `\":` inside a string as the end of a key, for example in `"\":"` (at least with [syntect](https://github.com/trishume/syntect), it might depend on the engine). Escaping the backslash in the regex fixes it.

(this definition has been useful in [xh](https://github.com/ducaale/xh), thank you!)