### PR TITLE
fix: support block folding for JSON Key-Value syntax

### DIFF
--- a/JSON Key-Value.YAML-tmLanguage
+++ b/JSON Key-Value.YAML-tmLanguage
@@ -1,44 +1,176 @@
-# [PackageDev] target_format: plist, ext: tmLanguage
+%YAML 1.2
 ---
 name: JSON Key-Value
-scopeName: source.json
-uuid: 4e5a820c-0650-4de9-b793-201999eeeb4f
-fileTypes:
-- json
+scope: source.json
+version: 2
 
-patterns:
-- comment: Single-line comment
-  match: //.*
-  name: comment.single.line.json
-- comment: Multi-line comment
-  begin: /\*
-  end: \*/
-  name: comment.block.json
-- comment: Key names
-  match: '"(?i)([^\"]+)"\s*?(:)'
-  captures:
-    '1':
-      name: keyword.other.name.json
-    '2':
-      name: punctuation.separator.mapping.key-value.json
-- comment: String values
-  name: string.quoted.json
-  begin: "\""
-  end: "\""
-  patterns:
-  - comment: Escape characters
-    name: constant.character.escape.json
-    match: \\[tnr"]
-- comment: Numeric values
-  name: constant.numeric.json
-  match: '\d+(?:(.)\d+)?'
-  captures:
-    '1':
-      name: punctuation.separator.decimal.json
-- comment: Boolean values
-  name: constant.language.boolean.json
-  match: 'true|false'
-- comment: Null value
-  name: constant.language.null.json
-  match: 'null'
+file_extensions:
+  - json
+  - json5
+  - sublime-build
+  - sublime-color-scheme
+  - sublime-commands
+  - sublime-completions
+  - sublime-keymap
+  - sublime-macro
+  - sublime-menu
+  - sublime-mousemap
+  - sublime-project
+  - sublime-settings
+  - sublime-theme
+  - sublime-workspace
+  - ipynb
+  - gltf
+
+hidden_file_extensions:
+  - Pipfile.lock
+  - sublime_session
+
+first_line_match: |-
+  (?xi:
+    ^ \s* // .*? -\*- .*? \bjson\b .*? -\*-  # editorconfig
+  )
+
+contexts:
+
+  prototype:
+    - include: comments
+
+  main:
+    - include: value
+
+  value:
+    - include: constant
+    - include: number
+    - include: string
+    - include: array
+    - include: object
+
+  array:
+    - match: \[
+      scope: punctuation.section.sequence.begin.json
+      push:
+        - meta_scope: meta.sequence.json
+        - match: \]
+          scope: punctuation.section.sequence.end.json
+          pop: 1
+        - include: value
+        - match: ','
+          scope: punctuation.separator.sequence.json
+        - match: '[^\s\]]'
+          scope: invalid.illegal.expected-sequence-separator.json
+
+  comments:
+    - match: /\*\*(?!/)
+      scope: punctuation.definition.comment.json
+      push:
+        - meta_scope: comment.block.documentation.json
+        - meta_include_prototype: false
+        - match: \*/
+          pop: 1
+        - match: ^\s*(\*)(?!/)
+          captures:
+            1: punctuation.definition.comment.json
+    - match: /\*
+      scope: punctuation.definition.comment.json
+      push:
+        - meta_scope: comment.block.json
+        - meta_include_prototype: false
+        - match: \*/
+          pop: 1
+    - match: (//).*$\n?
+      scope: comment.line.double-slash.js
+      captures:
+        1: punctuation.definition.comment.json
+
+  constant:
+    - match: \b(?:false|true)\b
+      scope: constant.language.boolean.json
+    - match: \bnull\b
+      scope: constant.language.null.json
+
+  number:
+    # handles integer and decimal numbers
+    - match: (-?)((?:0|[1-9]\d*)(?:(?:(\.)\d+)(?:[eE][-+]?\d+)?|(?:[eE][-+]?\d+)))
+      scope: meta.number.float.decimal.json
+      captures:
+        1: keyword.operator.arithmetic.json
+        2: constant.numeric.value.json
+        3: punctuation.separator.decimal.json
+    - match: (-?)(0|[1-9]\d*)
+      scope: meta.number.integer.decimal.json
+      captures:
+        1: keyword.operator.arithmetic.json
+        2: constant.numeric.value.json
+
+  object:
+    # a JSON object
+    - match: \{
+      scope: punctuation.section.mapping.begin.json
+      push:
+        - meta_scope: meta.mapping.json
+        - match: \}
+          scope: punctuation.section.mapping.end.json
+          pop: 1
+        - match: \"
+          scope: punctuation.definition.string.begin.json
+          push:
+            - clear_scopes: 1
+            - meta_scope: meta.mapping.key.json string.quoted.double.json support.type.other.json
+            - meta_include_prototype: false
+            - include: inside-string
+        - match: ':'
+          scope: punctuation.separator.key-value.json
+          push:
+            - match: ',|\s?(?=\})'
+              scope: invalid.illegal.expected-mapping-value.json
+              pop: 1
+            - match: (?=\S)
+              set:
+                - clear_scopes: 1
+                - meta_scope: meta.mapping.value.json
+                - include: value
+                - match: ''
+                  set:
+                    - match: ','
+                      scope: punctuation.separator.sequence.json
+                      pop: 1
+                    - match: \s*(?=\})
+                      pop: 1
+                    - match: \s(?!/[/*])(?=[^\s,])|[^\s,]
+                      scope: invalid.illegal.expected-mapping-separator.json
+                      pop: 1
+        - match: '[^\s\}]'
+          scope: invalid.illegal.expected-mapping-key.json
+
+  string:
+    - match: \"
+      scope: punctuation.definition.string.begin.json
+      push: inside-string
+
+  inside-string:
+    - meta_scope: string.quoted.double.json
+    - meta_include_prototype: false
+    - match: \"
+      scope: punctuation.definition.string.end.json
+      pop: 1
+    - include: string-escape
+    - match: \n
+      scope: invalid.illegal.unclosed-string.json
+      pop: 1
+
+  string-escape:
+    - match: |-
+        (?x:                # turn on extended mode
+          \\                # a literal backslash
+          (?:               # ...followed by...
+            ["\\/bfnrt]     # one of these characters
+            |               # ...or...
+            u               # a u
+            [0-9a-fA-F]{4}  # and four hex digits
+          )
+        )
+      scope: constant.character.escape.json
+    - match: \\.
+      scope: invalid.illegal.unrecognized-string-escape.json
 ...


### PR DESCRIPTION
1) Whole content taken from [`sublimehq/Packages`](https://github.com/sublimehq/Packages/blob/master/JSON/JSON.sublime-syntax)
2) Added fake scope `support.type.other.json` (see line 119) — themes I've checked binds wonderful color to it:
![Image 2023-03-01 03-35-04](https://user-images.githubusercontent.com/1984175/222015030-607f23f7-d29d-4949-8c16-fb53e6e90d6e.png)

PS: I didn't check the package, but check the solution itself
Probably It is better to remove the second file (`JSON Key-Value.tmLanguage`) to stay the only one definition